### PR TITLE
Minor updates to the scripts

### DIFF
--- a/scripts/rq1.sh
+++ b/scripts/rq1.sh
@@ -27,7 +27,7 @@ run_test() {
       fuzzer.run_hour=$run_hour \
       seed_name=$seed_name \
       map_name=$map_name \
-      run_name="$run_local_name"
+      run_name="$run_name"
 }
 
 for run_id in $repeat_lst; do

--- a/scripts/rq2.sh
+++ b/scripts/rq2.sh
@@ -27,7 +27,7 @@ run_test() {
       fuzzer.run_hour=$run_hour \
       seed_name=$seed_name \
       map_name=$map_name \
-      run_name="$run_local_name"
+      run_name="$run_name"
 }
 
 for run_id in $repeat_lst; do

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,33 @@
+ENV_NAME="decictor"
+
+# exit if conda is not installed
+if ! command -v conda &> /dev/null
+then
+    echo "Conda is not installed. Exiting..."
+    exit 1
+fi
+
+BASE_DIR=$(conda info --base)
+DECICTOR_PIP="$BASE_DIR/envs/$ENV_NAME/bin/pip"
+
+# create conda env decictor if not exist
+if ! conda info --envs | grep -q "decictor"
+then
+    echo "Creating conda enviroment $ENV_NAME"
+    conda create -n decictor python=3.7.16 -y
+else
+    echo "Conda envviroment $ENV_NAME exists"
+fi
+
+# install decictor dependencies
+echo "Installing dependencies"
+$DECICTOR_PIP install -r requirements.txt
+
+# install pytorch
+echo "Installing pytorch"
+$DECICTOR_PIP install torch==1.13.1+cu117 \
+    torchvision==0.14.1+cu117 \
+    torchaudio==0.13.1 \
+    --extra-index-url https://download.pytorch.org/whl/cu117
+
+echo -e "\033[0;32mDecictor is now ready to use with conda environment $ENV_NAME\033[0m"


### PR DESCRIPTION
This PR updates scripts under the `scripts` directory for the following reasons:

1. In `scripts/rq1.sh` and `scripts/rq2.sh`, the argument `run_name` had a typo (`run_local_name` instead of `run_name`) and caused outputs to be produced under `outputs/scenario_X/APPROACH/` instead of `outputs/scenario_X/APPROACH/run_X`. 

2. added a setup script to create conda environment `decictor` and install dependencies.